### PR TITLE
Add support for async generate

### DIFF
--- a/lib/json_serial/json_generator.dart
+++ b/lib/json_serial/json_generator.dart
@@ -1,5 +1,6 @@
 library source_gen.json_serial.generator;
 
+import 'dart:async';
 import 'package:analyzer/src/generated/element.dart';
 
 import 'package:source_gen/src/generator.dart';
@@ -13,7 +14,7 @@ class JsonGenerator extends GeneratorForAnnotation<JsonSerializable> {
   const JsonGenerator();
 
   @override
-  String generateForAnnotatedElement(
+  Future<String> generateForAnnotatedElement(
       Element element, JsonSerializable annotation) {
     if (element is! ClassElement) {
       var friendlyName = frieldlyNameForElement(element);
@@ -41,7 +42,8 @@ class JsonGenerator extends GeneratorForAnnotation<JsonSerializable> {
           todo: 'Make the following fields writable: ${finalFields.join(', ')}.');
     }
 
-    return _populateTemplate(classElement.displayName, fieldMap);
+    return new Future.value(
+        _populateTemplate(classElement.displayName, fieldMap));
   }
 
   @override

--- a/lib/src/generated_output.dart
+++ b/lib/src/generated_output.dart
@@ -1,12 +1,13 @@
 library source_gen.generated_output;
 
+import 'dart:async';
 import 'package:analyzer/src/generated/element.dart';
 
 import 'generator.dart';
 
 class GeneratedOutput {
   final Element sourceMember;
-  final String output;
+  final Future<String> output;
   final Generator generator;
 
   GeneratedOutput(this.sourceMember, this.generator, this.output);

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -4,18 +4,19 @@ import 'dart:mirrors';
 
 import 'package:analyzer/src/generated/element.dart';
 import 'utils.dart';
+import 'dart:async';
 
 abstract class Generator {
   const Generator();
 
-  String generate(Element element);
+  Future<String> generate(Element element);
 }
 
 abstract class GeneratorForAnnotation<T> extends Generator {
   const GeneratorForAnnotation();
 
   @override
-  String generate(Element element) {
+  Future<String> generate(Element element) {
     var matchingAnnotations =
         element.metadata.where((md) => matchAnnotation(T, md)).toList();
 
@@ -36,7 +37,7 @@ abstract class GeneratorForAnnotation<T> extends Generator {
     return generateForAnnotatedElement(element, annotationInstance);
   }
 
-  String generateForAnnotatedElement(Element element, T annotation);
+  Future<String> generateForAnnotatedElement(Element element, T annotation);
 }
 
 class InvalidGenerationSourceError {

--- a/test/generate_test.dart
+++ b/test/generate_test.dart
@@ -179,16 +179,16 @@ Future _createPackageStub(String pkgName) async {
 /// Doesn't generate output for any element
 class _NoOpGenerator extends Generator {
   const _NoOpGenerator();
-  String generate(Element element) => null;
+  Future<String> generate(Element element) => null;
 }
 
 /// Generates a single-line comment for each element
 class _TestGenerator extends Generator {
   const _TestGenerator();
 
-  String generate(Element element) {
+  Future<String> generate(Element element) {
     if (element is ClassElement) {
-      return '// Code for $element';
+      return new Future.value('// Code for $element');
     }
     return null;
   }

--- a/test/json_generator_test.dart
+++ b/test/json_generator_test.dart
@@ -52,7 +52,7 @@ void main() {
   group('valid inputs', () {
     test('class with no fields', () async {
       var element = await _getClassForCodeString('Person');
-      var output = _generator.generate(element);
+      var output = await _generator.generate(element);
 
       expect(output, isNotNull);
 


### PR DESCRIPTION
Generators will likely need to read a template referenced from the annotated class.
Since all I/O is async, changed generate signature and GeneratedOutput.output to futures.